### PR TITLE
/luna patch-release 2.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.0.6
+
+- _(Chore)_ Upgrade base image to `haproxy:2.3.5-alpine`
+
 ## 2.0.5
 
 - _(Chore)_ Upgrade base image to `haproxy:2.3.3-alpine`


### PR DESCRIPTION
## 2.0.6

- _(Chore)_ Upgrade base image to `haproxy:2.3.5-alpine`

## 2.0.5

- _(Chore)_ Upgrade base image to `haproxy:2.3.3-alpine`
- _(Internal)_ Update template via diana
